### PR TITLE
Fix missing return value error by changing the return type to void

### DIFF
--- a/fast-prime.c
+++ b/fast-prime.c
@@ -160,7 +160,7 @@ int check_file(maybe_prime)
     return 1;
 }
 
-int new_file(void)
+void new_file(void)
 {
     //creates a new file "primes.log", with "2" and "3" in it.
     FILE *primes;


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).